### PR TITLE
Change keyword polyline to polygon to match new specification

### DIFF
--- a/gravityturn/earth.xml
+++ b/gravityturn/earth.xml
@@ -26,10 +26,10 @@
     </shape>
     <!-- Create Launch Pad on Earth -->
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="strip"
         points="-1000.0,  6378.16e3;
                  1000.0,  6378.16e3">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
 </object>

--- a/gravityturn/rocket_body.xml
+++ b/gravityturn/rocket_body.xml
@@ -17,33 +17,33 @@
         inertia="10000000.0"
     />
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="loop"
         points=" -2.7, -27.0;
                   2.7, -27.0;
                   2.7,  18.0;
                   0.0,  27.0;
                  -2.7,  18.0">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="loop"
         points=" -2.7, -27.0;
                  -5.7, -27.0;
                  -5.7,   0.0;
                  -4.2,   4.0;
                  -2.7,   0.0;">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="loop"
         points="  2.7, -27.0;
                   5.7, -27.0;
                   5.7,   0.0;
                   4.2,   4.0;
                   2.7,   0.0;">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>    
 </object>

--- a/sputnik/sputnik.xml
+++ b/sputnik/sputnik.xml
@@ -24,24 +24,24 @@
         <visuals type="shape_visuals_circle"/>
     </shape>
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="single"
         points=" -0.29,  0.0;
                  -0.50, -1.5;">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="single"
         points="  0.00,  0.0;
                   0.00, -1.6;">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="single"
         points="  0.29,  0.0;
                   0.50, -1.5;">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
 </object>

--- a/sunlight/sunlight.xml
+++ b/sunlight/sunlight.xml
@@ -17,10 +17,10 @@
         inertia="1.0"
     />
     <shape
-        type="shape_polyline"
+        type="shape_polygon"
         line_type="single"
         points=" -299792458.0,  0.0;
                           0.0, 0.0;">
-        <visuals type="shape_visuals_polyline"/>
+        <visuals type="shape_visuals_polygon"/>
     </shape>
 </object>


### PR DESCRIPTION
In preparation for filled polygons in contrast to polylines, the internal and external keywords changed. In the upcoming versions of planeworld, polygons will include polylines, based on the already known types (LINE_STRIP, LINE_LOOP, SINGLE + FILLED[new]).
The differentiation is needed since automatic calculation of center of mass and inertia is being implemented.